### PR TITLE
Add Terraform state bucket 

### DIFF
--- a/terraform/.terraform.lock.hcl
+++ b/terraform/.terraform.lock.hcl
@@ -1,0 +1,22 @@
+# This file is maintained automatically by "terraform init".
+# Manual edits may be lost in future updates.
+
+provider "registry.terraform.io/hashicorp/google" {
+  version     = "5.41.0"
+  constraints = "~> 5.41.0"
+  hashes = [
+    "h1:J41GybtL77Jk8f+CVnIQ5lR5wdY/uiOOABOXWlEc2qE=",
+    "zh:0c650a7f2291db37b961548d6e62beffe8d242ef35837a44a34833e7cee38196",
+    "zh:26a5620048708fb64bb357622584a3a9d0b300473929e575f2c1945247aadd14",
+    "zh:31b9b8412185716f87256036cc6dc762e7e1b2d36622122b40159225b5d428a8",
+    "zh:4c9d9d0c185a190ffad801772eca51f5d924d5044c7b16d156e65601eb7077c7",
+    "zh:4d93bd479f977689c09121b1ec2cf8fadd9511e9a9e78b1d73708cb67d43acfd",
+    "zh:60ca5275f555c4fdf521733d023792c8b6de121c1fc1628116c3f4be7c570cbb",
+    "zh:9bce12e395809ef0b569fb65064a9608841afbaad5c36017342a9a9ecd77f1c8",
+    "zh:a4cfae44d1e2e2e7c977460cabcf1fd8803bf2b4f567dfc957fbebf6863e7e94",
+    "zh:b3c583f549d1879ada90cce7a0c8598116a2c0d76c344daf3ea144811f34a961",
+    "zh:e21dcc534d0417051efd40633c4d308d1905fcf8d856297ee4dc57136f600245",
+    "zh:f569b65999264a9416862bca5cd2a6177d94ccb0424f3a4ef424428912b9cb3c",
+    "zh:fc755a262a5ffd6ce2d51155ab92d53f16b16aa290e2c63715abb4d133640f78",
+  ]
+}

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -6,4 +6,8 @@ terraform {
       version = "~> 5.41.0"
     }
   }
+  backend "gcs" {
+    bucket = "${var.project_name}-tfstate-backend"
+    prefix = var.project_name
+  }
 }

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -1,0 +1,4 @@
+provider "google" {
+  project = "aiagent-449708"
+  region  = "asia-northeast1"
+}

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -7,7 +7,7 @@ terraform {
     }
   }
   backend "gcs" {
-    bucket = "${var.project_name}-tfstate-backend"
-    prefix = var.project_name
+    bucket = "videoflowai-tfstate-backend"
+    prefix = "videoflowai"
   }
 }

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -1,4 +1,9 @@
-provider "google" {
-  project = "aiagent-449708"
-  region  = "asia-northeast1"
+terraform {
+  required_version = ">= 1.9.4, < 2.0.0"
+  required_providers {
+    google = {
+      source  = "hashicorp/google"
+      version = "~> 5.41.0"
+    }
+  }
 }

--- a/terraform/provider.tf
+++ b/terraform/provider.tf
@@ -1,0 +1,4 @@
+provider "google" {
+  project = "aiagent-449708"
+  region  = "asia-northeast1"
+}

--- a/terraform/state.tf
+++ b/terraform/state.tf
@@ -1,4 +1,4 @@
 resource "google_storage_bucket" "tfstate_backend" {
   location = "asia-northeast1"
-  name     = "tfstate-backend"
+  name     = "${var.project_name}-tfstate-backend"
 }

--- a/terraform/state.tf
+++ b/terraform/state.tf
@@ -1,0 +1,4 @@
+resource "google_storage_bucket" "tfstate_backend" {
+  location = "asia-northeast1"
+  name     = "tfstate-backend"
+}

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -1,0 +1,4 @@
+variable "project_name" {
+  type    = string
+  default = "videoflowai"
+}


### PR DESCRIPTION
This pull request introduces several changes to the Terraform configuration files to set up and manage a Google Cloud Storage backend for Terraform state. The most important changes include specifying the required Terraform version and provider, configuring the Google provider, defining a storage bucket for the Terraform state, and adding a project name variable.

Terraform configuration updates:

* [`terraform/main.tf`](diffhunk://#diff-2e617c7870fa918457b1eee1c7d67ba82f19d043ae7b7918db26873e18793028R1-R13): Added required Terraform version, specified the Google provider version, and configured the backend to use a Google Cloud Storage bucket.

Google provider configuration:

* [`terraform/provider.tf`](diffhunk://#diff-3136f4abdecb74a01476d52578a24f108e104076938c7c5f62ded9266d5b6d0cR1-R4): Configured the Google provider with the project ID and region.

Resource definition:

* [`terraform/state.tf`](diffhunk://#diff-9ee8b21b89ce0f8e4282c15249634a4889ca0bf0f6db89d3c2a2672fc3d74cbeR1-R4): Added a resource definition for a Google Cloud Storage bucket to store the Terraform state.

Variable definition:

* [`terraform/variables.tf`](diffhunk://#diff-b25e8cb262b29f5005a96d0c4a06a3deb77698fa6e11e4f43b21f6f4ad0f45e4R1-R4): Added a variable for the project name with a default value.

Lock file update:

* [`terraform/.terraform.lock.hcl`](diffhunk://#diff-845d0f38d4ba0c7d301f2a289b3d7304a7298455f93833c345fe398654b095baR1-R22): Added a lock file to manage provider versions and dependencies automatically.