### PR TITLE
Add GoogleCloud WIF resources

### DIFF
--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -11,3 +11,23 @@ terraform {
     prefix = "videoflowai"
   }
 }
+
+locals {
+  services = toset([
+    "run.googleapis.com",
+    "cloudfunctions.googleapis.com",
+    "pubsub.googleapis.com",
+    "storage.googleapis.com",
+    "secretmanager.googleapis.com",
+    "artifactregistry.googleapis.com",
+    "youtube.googleapis.com",
+    "texttospeech.googleapis.com",
+    "iam.googleapis.com",
+  ])
+}
+
+resource "google_project_service" "service" {
+  for_each           = local.services
+  service            = each.value
+  disable_on_destroy = false
+}

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -31,3 +31,8 @@ resource "google_project_service" "service" {
   service            = each.value
   disable_on_destroy = false
 }
+
+module "wif" {
+  source              = "./module/wif"
+  backend_bucket_name = google_storage_bucket.tfstate_backend.name
+}

--- a/terraform/module/wif/github.tf
+++ b/terraform/module/wif/github.tf
@@ -4,17 +4,14 @@ locals {
 
 resource "google_project_iam_member" "wif_principal" {
   for_each = toset([
-    "roles/compute.networkAdmin",
-    "roles/compute.instanceAdmin.v1",
-    "roles/editor",
+    "roles/run.admin",
+    "roles/cloudfunctions.developer",
+    "roles/pubsub.admin",
+    "roles/storage.objectAdmin",
+    "roles/secretmanager.secretAccessor",
+    "roles/artifactregistry.writer"
   ])
   project = data.google_project.current.project_id
   role    = each.value
   member  = "principalSet://iam.googleapis.com/${google_iam_workload_identity_pool.pool.name}/attribute.repository/${local.my_github_repository_owner}/${local.my_github_repository}"
-}
-
-resource "google_storage_bucket_iam_member" "backend_viewer" {
-  bucket = var.backend_bucket_name
-  role   = "roles/storage.objectViewer"
-  member = "principalSet://iam.googleapis.com/${google_iam_workload_identity_pool.pool.name}/attribute.repository/${local.my_github_repository_owner}/${local.my_github_repository}"
 }

--- a/terraform/module/wif/github.tf
+++ b/terraform/module/wif/github.tf
@@ -1,0 +1,20 @@
+locals {
+  my_github_repository = "VideoFlowAI"
+}
+
+resource "google_project_iam_member" "wif_principal" {
+  for_each = toset([
+    "roles/compute.networkAdmin",
+    "roles/compute.instanceAdmin.v1",
+    "roles/editor",
+  ])
+  project = data.google_project.current.project_id
+  role    = each.value
+  member  = "principalSet://iam.googleapis.com/${google_iam_workload_identity_pool.pool.name}/attribute.repository/${local.my_github_repository_owner}/${local.my_github_repository}"
+}
+
+resource "google_storage_bucket_iam_member" "backend_viewer" {
+  bucket = var.backend_bucket_name
+  role   = "roles/storage.objectViewer"
+  member = "principalSet://iam.googleapis.com/${google_iam_workload_identity_pool.pool.name}/attribute.repository/${local.my_github_repository_owner}/${local.my_github_repository}"
+}

--- a/terraform/module/wif/pool.tf
+++ b/terraform/module/wif/pool.tf
@@ -1,0 +1,30 @@
+data "google_project" "current" {}
+
+resource "google_iam_workload_identity_pool" "pool" {
+  workload_identity_pool_id = "github-pool"
+  display_name              = "github-pool"
+  description               = "for github actions workflows"
+}
+
+locals {
+  my_github_repository_owner = "wakame1367"
+}
+
+resource "google_iam_workload_identity_pool_provider" "provider" {
+  workload_identity_pool_id = google_iam_workload_identity_pool.pool.workload_identity_pool_id
+
+  workload_identity_pool_provider_id = "github-provider"
+  display_name                       = "github-provider"
+  description                        = "for github actions workflows"
+
+  attribute_mapping = {
+    "google.subject"             = "assertion.sub"
+    "attribute.repository"       = "assertion.repository"
+    "attribute.repository_owner" = "assertion.repository_owner"
+  }
+  attribute_condition = "assertion.repository_owner == '${local.my_github_repository_owner}'"
+
+  oidc {
+    issuer_uri = "https://token.actions.githubusercontent.com"
+  }
+}

--- a/terraform/module/wif/variables.tf
+++ b/terraform/module/wif/variables.tf
@@ -1,0 +1,4 @@
+variable "backend_bucket_name" {
+  type    = string
+  default = "videoflowai-tfstate-backend"
+}


### PR DESCRIPTION
This pull request includes significant changes to the Terraform configuration to manage Google Cloud resources and integrate with GitHub for workload identity federation. The most important changes include the addition of local variables, new resources for enabling Google Cloud services, and configuration for workload identity federation.

### Terraform Configuration Updates:

* [`terraform/main.tf`](diffhunk://#diff-2e617c7870fa918457b1eee1c7d67ba82f19d043ae7b7918db26873e18793028R14-R38): Added a `locals` block defining a set of Google Cloud services to be enabled and a `google_project_service` resource to manage these services. Additionally, included a module for workload identity federation (`wif`).

* [`terraform/module/wif/github.tf`](diffhunk://#diff-d248e128193dc0a42d1099e5860cde1c6b43cfb8b090693f8a5905d59d84a285R1-R17): Introduced local variables for GitHub repository information and a `google_project_iam_member` resource to assign IAM roles to the workload identity federation principal.

* [`terraform/module/wif/pool.tf`](diffhunk://#diff-2a7fc207685e956a2ec83de8c9abd07f2e31da3bbbc72fbfe4a94283857e381eR1-R30): Added a `google_iam_workload_identity_pool` resource and a `google_iam_workload_identity_pool_provider` resource to configure workload identity federation with GitHub Actions. Included a `data "google_project"` block to fetch the current project information.

* [`terraform/module/wif/variables.tf`](diffhunk://#diff-4ff08b6843cc30d79aa06c4a698595113a81eefce4de3ec4151d4dc92e05646aR1-R4): Defined a new variable `backend_bucket_name` to specify the name of the backend bucket for storing Terraform state.