### PR TITLE
Add GitHubActions CICD for GoogleCloud

### DIFF
--- a/.github/cd.yml
+++ b/.github/cd.yml
@@ -1,0 +1,49 @@
+name: '1.2. infra CD for dev'
+
+on:
+  push:
+    branches:
+      - "main"
+  workflow_dispatch:
+
+jobs:
+  cd_dev:
+    name: 'cd_dev'
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        shell: bash
+    permissions:
+      id-token: write
+      contents: read
+    env:
+      WORKLOAD_IDENTITY_PROVIDER: "projects/500315244546/locations/global/workloadIdentityPools/github-pool/providers/github-provider"
+      PROJECT_ID: "tmp-20240814"
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Authenticate to Google Cloud
+        uses: google-github-actions/auth@v2
+        with:
+          workload_identity_provider: ${{ env.WORKLOAD_IDENTITY_PROVIDER }}
+          project_id: ${{ env.PROJECT_ID }}
+
+      - name: Detect Terraform version
+        run: |
+          printf "TF_VERSION=%s" $(cat .terraform-version) >> $GITHUB_ENV
+
+      - name: Setup Terraform
+        uses: hashicorp/setup-terraform@v3
+        with:
+          terraform_version: ${{ env.TF_VERSION }}
+          terraform_wrapper: false
+
+      - name: Terraform Init
+        run: terraform init
+        working-directory: ./env/dev
+
+      - name: Terraform Apply
+        run: terraform apply -auto-approve
+        working-directory: ./env/dev

--- a/.github/cd.yml
+++ b/.github/cd.yml
@@ -1,4 +1,4 @@
-name: '1.2. infra CD for dev'
+name: 'infra CD for dev'
 
 on:
   push:
@@ -17,8 +17,8 @@ jobs:
       id-token: write
       contents: read
     env:
-      WORKLOAD_IDENTITY_PROVIDER: "projects/500315244546/locations/global/workloadIdentityPools/github-pool/providers/github-provider"
-      PROJECT_ID: "tmp-20240814"
+      WORKLOAD_IDENTITY_PROVIDER: "projects/216651416597/locations/global/workloadIdentityPools/github-pool/providers/github-provider"
+      PROJECT_ID: "aiagent-449708"
 
     steps:
       - name: Checkout
@@ -42,8 +42,8 @@ jobs:
 
       - name: Terraform Init
         run: terraform init
-        working-directory: ./env/dev
+        working-directory: ./terraform
 
       - name: Terraform Apply
         run: terraform apply -auto-approve
-        working-directory: ./env/dev
+        working-directory: ./terraform

--- a/.github/ci.yml
+++ b/.github/ci.yml
@@ -1,0 +1,55 @@
+name: "1.1. infra CI for dev"
+
+on:
+  pull_request:
+    branches:
+      - "main"
+
+jobs:
+  ci_dev:
+    name: "ci_dev"
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        shell: bash
+    permissions:
+      id-token: write
+      contents: read
+    env:
+      WORKLOAD_IDENTITY_PROVIDER: "projects/500315244546/locations/global/workloadIdentityPools/github-pool/providers/github-provider"
+      PROJECT_ID: "tmp-20240814"
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Authenticate to Google Cloud
+        uses: google-github-actions/auth@v2
+        with:
+          workload_identity_provider: ${{ env.WORKLOAD_IDENTITY_PROVIDER }}
+          project_id: ${{ env.PROJECT_ID }}
+
+      - name: Detect Terraform version
+        run: |
+          printf "TF_VERSION=%s" $(cat .terraform-version) >> $GITHUB_ENV
+
+      - name: Setup Terraform
+        uses: hashicorp/setup-terraform@v3
+        with:
+          terraform_version: ${{ env.TF_VERSION }}
+          terraform_wrapper: false
+
+      - name: Terraform Format
+        run: terraform fmt -recursive -check
+
+      - name: Terraform Init
+        run: terraform init
+        working-directory: ./env/dev
+
+      - name: Terraform Validate
+        run: terraform validate -no-color
+        working-directory: ./env/dev
+
+      - name: Terraform Plan
+        run: terraform plan -no-color
+        working-directory: ./env/dev

--- a/.github/ci.yml
+++ b/.github/ci.yml
@@ -1,4 +1,4 @@
-name: "1.1. infra CI for dev"
+name: "infra CI for dev"
 
 on:
   pull_request:
@@ -16,8 +16,8 @@ jobs:
       id-token: write
       contents: read
     env:
-      WORKLOAD_IDENTITY_PROVIDER: "projects/500315244546/locations/global/workloadIdentityPools/github-pool/providers/github-provider"
-      PROJECT_ID: "tmp-20240814"
+      WORKLOAD_IDENTITY_PROVIDER: "projects/216651416597/locations/global/workloadIdentityPools/github-pool/providers/github-provider"
+      PROJECT_ID: "aiagent-449708"
 
     steps:
       - name: Checkout
@@ -44,12 +44,12 @@ jobs:
 
       - name: Terraform Init
         run: terraform init
-        working-directory: ./env/dev
+        working-directory: ./terraform
 
       - name: Terraform Validate
         run: terraform validate -no-color
-        working-directory: ./env/dev
+        working-directory: ./terraform
 
       - name: Terraform Plan
         run: terraform plan -no-color
-        working-directory: ./env/dev
+        working-directory: ./terraform


### PR DESCRIPTION
This pull request introduces new continuous integration (CI) and continuous deployment (CD) workflows for the infrastructure in the development environment. The most important changes include the addition of a CI workflow for pull requests and a CD workflow for pushes to the main branch.

New CI/CD workflows:

* [`.github/ci.yml`](diffhunk://#diff-46b2e9aaccec219605073cc540205c5681158294ef4acb0365278756fa19097cR1-R55): Added a CI workflow named "infra CI for dev" that runs on pull requests to the main branch. This workflow includes steps for checking out the code, authenticating to Google Cloud, setting up Terraform, and running Terraform commands to format, initialize, validate, and plan the infrastructure.
* [`.github/cd.yml`](diffhunk://#diff-5c5b1f2fff52d953cd8417b4ba46f069fc56bf32f4a8e94df6e245e8288c463aR1-R49): Added a CD workflow named "infra CD for dev" that runs on pushes to the main branch. This workflow includes steps for checking out the code, authenticating to Google Cloud, setting up Terraform, and running Terraform commands to initialize and apply the infrastructure changes.