### PR TITLE
Add Google Cloud SecretManager Resources

### DIFF
--- a/terraform/.gitignore
+++ b/terraform/.gitignore
@@ -37,4 +37,5 @@ override.tf.json
 .terraformrc
 terraform.rc
 
+credentials.json
 # End of https://www.toptal.com/developers/gitignore/api/terraform

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -32,6 +32,19 @@ resource "google_project_service" "service" {
   disable_on_destroy = false
 }
 
+resource "google_secret_manager_secret" "youtube_api_credentials" {
+  project   = var.project_id
+  secret_id = "youtube-api-credentials"
+
+  replication {
+  }
+}
+
+resource "google_secret_manager_secret_version" "youtube_api_credentials_version" {
+  secret      = google_secret_manager_secret.youtube_api_credentials.id
+  secret_data = filebase64("credentials.json")
+}
+
 module "wif" {
   source              = "./module/wif"
   backend_bucket_name = google_storage_bucket.tfstate_backend.name

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -37,6 +37,7 @@ resource "google_secret_manager_secret" "youtube_api_credentials" {
   secret_id = "youtube-api-credentials"
 
   replication {
+    auto {}
   }
 }
 

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -2,3 +2,13 @@ variable "project_name" {
   type    = string
   default = "videoflowai"
 }
+
+variable "project_id" {
+  type    = string
+  default = "aiagent-449708"
+}
+
+variable "region" {
+  type    = string
+  default = "asia-northeast1"
+}


### PR DESCRIPTION
This pull request includes several changes to the Terraform configuration to manage Google Cloud resources. The most important changes include adding new resources for managing YouTube API credentials and introducing new variables for project configuration.

New resources for managing YouTube API credentials:

* [`terraform/main.tf`](diffhunk://#diff-2e617c7870fa918457b1eee1c7d67ba82f19d043ae7b7918db26873e18793028R35-R48): Added resources `google_secret_manager_secret` and `google_secret_manager_secret_version` to store and manage YouTube API credentials securely.

New variables for project configuration:

* [`terraform/variables.tf`](diffhunk://#diff-b25e8cb262b29f5005a96d0c4a06a3deb77698fa6e11e4f43b21f6f4ad0f45e4R5-R14): Introduced new variables `project_id` and `region` to allow configuration of the project ID and region.

Updates to `.gitignore`:

* [`terraform/.gitignore`](diffhunk://#diff-d819b47c9d1b5dac74644ad92a42826b3e571c3852ba9b5870510b7c4b927c74R40): Added `credentials.json` to the `.gitignore` file to ensure sensitive credentials are not tracked in version control.